### PR TITLE
Updated consistent naming for unsafe functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Additional `unsafe_function`s are always welcome. When designing a new one, plea
 consider the following:
 
 1. **Does this replicate a gdscript behavior?** In general, we want to only add functions
-that expose some gdscript behavior. For example, `require_typed_node()` functions the same
+that expose some gdscript behavior. For example, `require_node()` functions the same
 as `get_node()` in gdscript.
 2. **How safe is it?** Yes, it is called `unsafe_functions`, but this is unsafe in the
 context of rust. Much like the comment above, we should be trying to duplicate some 
@@ -42,3 +42,6 @@ gdscript feature as well as its risks. All panics should be clearly documented a
 intuitive given the function name, and all unsafe code should be documented and safe 
 in standard use cases. Simply stating that a function calls `assume_safe()` is a good
 enough hint for the user.
+3. **Is the name clear enough?** In general, you can replace `get_` with `require_`. If 
+your function does more than that, make sure the name outlines the potential issues. For
+example, `require_node()` implies there will be an issue if the node is not there.

--- a/gdrust/src/unsafe_functions/spatial_ext.rs
+++ b/gdrust/src/unsafe_functions/spatial_ext.rs
@@ -1,32 +1,18 @@
-use euclid::approxeq::ApproxEq;
-use euclid::{RigidTransform3D, Rotation3D, Trig};
 use gdnative::api::Spatial;
 use gdnative::object::SubClass;
-use gdnative::prelude::Transform;
+use gdnative::prelude::Basis;
 use gdnative::TRef;
-use num_traits::cast::NumCast;
-use num_traits::Float;
 
 pub trait SpatialExt {
-    fn set_rotation<T: Copy + NumCast + Float + ApproxEq<T> + Trig, Src: Copy, Dst: Copy>(
-        &self,
-        rotation: Rotation3D<T, Src, Dst>,
-    );
+    /// Sets the rotation of the Spatial. Similar to `spatial.global_transform.basis = basis`.
+    fn set_global_rotation(&self, basis: Basis);
 }
 
 impl<'a, Class: SubClass<Spatial>> SpatialExt for TRef<'a, Class> {
-    fn set_rotation<T: Copy + NumCast + Float + ApproxEq<T> + Trig, Src: Copy, Dst: Copy>(
-        &self,
-        rotation: Rotation3D<T, Src, Dst>,
-    ) {
+    fn set_global_rotation(&self, rotation: Basis) {
         let spatial = self.upcast::<Spatial>();
-        let origin = spatial.global_transform().origin;
-        let rigid_transform = RigidTransform3D {
-            rotation: rotation.to_untyped().cast_unit(),
-            translation: origin.cast_unit().cast(),
-        };
-        spatial.set_global_transform(Transform::from_transform(
-            &rigid_transform.to_transform().cast(),
-        ));
+        let mut transform = spatial.global_transform();
+        transform.basis = rotation;
+        spatial.set_global_transform(transform);
     }
 }


### PR DESCRIPTION
```
require_typed_node -> expect_node
parent_as -> expect_parent
```
Added `expect_tree`