### PR TITLE
fix `implied_bounds_entailment` future compatibility lint

### DIFF
--- a/gdrust/src/unsafe_functions/node_ext.rs
+++ b/gdrust/src/unsafe_functions/node_ext.rs
@@ -45,7 +45,7 @@ impl<'a, T: SubClass<Node>> NodeExt for TRef<'a, T> {
     fn expect_node<Child: SubClass<Node>, P: Into<NodePath>>(
         &self,
         path: P,
-    ) -> TRef<'a, Child, Shared> {
+    ) -> TRef<'_, Child, Shared> {
         let path = path.into();
         unsafe {
             self.upcast()
@@ -59,7 +59,7 @@ impl<'a, T: SubClass<Node>> NodeExt for TRef<'a, T> {
         }
     }
 
-    fn expect_parent<Child: SubClass<Node>>(&self) -> TRef<'a, Child, Shared> {
+    fn expect_parent<Child: SubClass<Node>>(&self) -> TRef<'_, Child, Shared> {
         unsafe {
             self.upcast()
                 .get_parent()


### PR DESCRIPTION
Your crate unintentionally relied on a soundness bug in the Rust compiler, see https://github.com/rust-lang/rust/issues/105572 for more info. This lint will be a hard error in a future release. This PR fixes that lint.